### PR TITLE
Add basic BM1370 ASIC support

### DIFF
--- a/driver-bitaxe.h
+++ b/driver-bitaxe.h
@@ -47,9 +47,10 @@ enum miner_state {
 };
 
 enum miner_asic {
-	BM1384 = 1,
-	BM1387,
-	BM1397
+        BM1384 = 1,
+        BM1387,
+        BM1397,
+        BM1370
 };
 
 enum plateau_type {


### PR DESCRIPTION
## Summary
- introduce BM1370 in ASIC enum
- add BM1370 handling in compac_detect_one and runtime chip detection
- implement BM1370 frequency ping and setting
- parse BM1370 nonces
- generate BM1370 tasks in busy_work/init_task

## Testing
- `make -n` *(fails: `No targets specified and no makefile found`)*