### PR TITLE
Add Docker build environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+*.o
+*.a
+*.lo
+*.la
+*.bin
+build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    build-essential autoconf automake libtool pkg-config \
+    libcurl4-openssl-dev libudev-dev libusb-1.0-0-dev \
+    libncurses5-dev zlib1g-dev git && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+COPY . /workspace
+
+RUN ./autogen.sh && ./configure --enable-bitaxe && make -j"$(nproc)"
+
+CMD ["bash"]

--- a/docker-build.txt
+++ b/docker-build.txt
@@ -1,0 +1,23 @@
+Building cgminer using Docker
+-----------------------------
+
+This document describes how to compile cgminer-asic inside a Docker container.
+
+1. Install Docker on your system.
+2. From the repository root build the Docker image:
+
+        docker build -t cgminer-asic .
+
+   This produces an image with all required build dependencies and a compiled
+   copy of cgminer.
+3. Run a container from the image:
+
+        docker run --rm -it cgminer-asic
+
+   The source tree is located under /workspace inside the container and
+   cgminer is compiled during the image build. If you want to rebuild the
+   binary, run the following commands inside the container:
+
+        ./autogen.sh
+        ./configure --enable-bitaxe
+        make -j"$(nproc)"


### PR DESCRIPTION
## Summary
- provide Dockerfile for building cgminer
- document Docker usage in `docker-build.txt`
- add `.dockerignore` to trim build context

## Testing
- `./autogen.sh`
- `./configure --enable-bitaxe`
- `make -j"$(nproc)"`