### PR TITLE
Add helper for Docker build logs

### DIFF
--- a/build-with-logs.sh
+++ b/build-with-logs.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Use first argument as logfile name or default to build.log
+LOGFILE="${1:-build.log}"
+
+echo "Logging build output to ${LOGFILE}"
+
+# Redirect all stdout and stderr to tee so output is on console and in file
+exec > >(tee "$LOGFILE") 2>&1
+
+./autogen.sh
+./configure --enable-bitaxe
+make -j"$(nproc)"
+

--- a/docker-build.txt
+++ b/docker-build.txt
@@ -21,3 +21,11 @@ This document describes how to compile cgminer-asic inside a Docker container.
         ./autogen.sh
         ./configure --enable-bitaxe
         make -j"$(nproc)"
+
+   To capture detailed build logs, you can run the provided helper script
+   instead:
+
+        ./build-with-logs.sh
+
+   This stores the combined stdout and stderr output in `build.log` so you
+   can inspect any errors after the build finishes.


### PR DESCRIPTION
## Summary
- provide a `build-with-logs.sh` helper to capture build output
- document the helper in `docker-build.txt`

## Testing
- `./build-with-logs.sh > /tmp/build-test.log`
