### PR TITLE
Add support for Espressif-based BM1370 bitaxe

### DIFF
--- a/usbutils.c
+++ b/usbutils.c
@@ -1134,10 +1134,10 @@ static struct usb_find_devices find_dev[] = {
 		INTINFO(gek2_ints) },
 #endif
 #ifdef USE_BITAXE
-	{
-		.drv = DRIVER_bitaxe,
-		.name = "AXE",
-		.ident = IDENT_GSF,
+        {
+                .drv = DRIVER_bitaxe,
+                .name = "AXE",
+                .ident = IDENT_GSF,
 		.idVendor = 0x0403,
 		.idProduct = 0x6015, //jim.sh
 		.iManufacturer = "FTDI",
@@ -1145,12 +1145,24 @@ static struct usb_find_devices find_dev[] = {
 		.config = 1,
 		.timeout = COMPAC_TIMEOUT_MS,
 		.latency = LATENCY_UNUSED,
-		INTINFO(gek2_ints) },
-	{
-		.drv = DRIVER_bitaxe,
-		.name = "AXE",
-		.ident = IDENT_GSF,
-		.idVendor = 0x0403,
+                INTINFO(gek2_ints) },
+        {
+                .drv = DRIVER_bitaxe,
+                .name = "AXE",
+                .ident = IDENT_AXE,
+                .idVendor = 0x303a,
+                .idProduct = 0x1001,
+                .iManufacturer = "Espressif",
+                .iProduct = "USB JTAG/serial debug unit",
+                .config = 1,
+                .timeout = COMPAC_TIMEOUT_MS,
+                .latency = LATENCY_UNUSED,
+                INTINFO(gek2_ints) },
+        {
+                .drv = DRIVER_bitaxe,
+                .name = "AXE",
+                .ident = IDENT_GSF,
+                .idVendor = 0x0403,
 		.idProduct = 0x6001, //FT232R
 		.iManufacturer = "FTDI",
 		.iProduct = "FT232R USB UART", //FT232R

--- a/usbutils.h
+++ b/usbutils.h
@@ -206,8 +206,9 @@ enum sub_ident {
 	IDENT_LIN,
 	IDENT_LLT,
 	IDENT_MMQ,
-	IDENT_NFU,
-	IDENT_OSM
+        IDENT_NFU,
+        IDENT_OSM,
+        IDENT_AXE
 };
 
 struct usb_find_devices {


### PR DESCRIPTION
## Summary
- detect Espressif `303a:1001` USB JTAG/serial device for BM1370 bitaxe
- map the new device to BM1370 ASIC type
- handle IDENT_AXE throughout bitaxe driver

## Testing
- `./autogen.sh`
- `./configure --enable-bitaxe`
- `make -j"$(nproc)"`